### PR TITLE
Fix state normalization logic

### DIFF
--- a/app.py
+++ b/app.py
@@ -356,7 +356,8 @@ class BillTracker:
         if len(state_input) == 2 and state_input.upper() in state_mapping.values():
             return state_input.upper()
         
-        # If it's a full state name        return state_mapping.get(state_lower, state_input.upper() if len(state_input) == 2 else None)
+        # If it's a full state name
+        return state_mapping.get(state_lower, state_input.upper() if len(state_input) == 2 else None)
     
     def _get_mock_bills(self, keyword):
         """Return enhanced mock bill data with realistic Congress.gov URLs"""

--- a/test_app.py
+++ b/test_app.py
@@ -44,7 +44,12 @@ def test_bill_tracker():
         bills = tracker.search_bills_by_state("CA", limit=5)
         assert isinstance(bills, list), "search_bills_by_state should return a list"
         print(f"✓ State search returned {len(bills)} bills")
-        
+
+        # Test state normalization
+        state_abbr = tracker._normalize_state("California")
+        assert state_abbr == "CA", "_normalize_state should return state abbreviation"
+        print("✓ State normalization working")
+
         return True
     except Exception as e:
         print(f"✗ BillTracker test failed: {e}")


### PR DESCRIPTION
## Summary
- fix `_normalize_state` so that full state names are converted to abbreviations
- verify state normalization in tests

## Testing
- `python3 test_app.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685884aa40f4832ca51a92759beea524